### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -3,6 +3,10 @@ name: Release Prep
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   prepare-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jamenamcinteer/react-qr-barcode-scanner/security/code-scanning/1](https://github.com/jamenamcinteer/react-qr-barcode-scanner/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for the tasks performed. Since the workflow involves reading repository contents, pushing changes, and creating pull requests, the permissions should be set as follows:
- `contents: write` for pushing changes and tags.
- `pull-requests: write` for creating pull requests.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as this workflow has only one job (`prepare-release`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
