### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -25,6 +27,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/jamenamcinteer/react-qr-barcode-scanner/security/code-scanning/4](https://github.com/jamenamcinteer/react-qr-barcode-scanner/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the `GITHUB_TOKEN` to perform the tasks in each job. For this workflow:
- The `build` job only requires read access to repository contents.
- The `publish-npm` job requires read access to repository contents and write access to packages for publishing to npm.

The `permissions` block can be added at the job level to ensure each job has the least privileges necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
