### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 0 */14 * *'
   workflow_dispatch: # Optional: Allow manual trigger
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   dependency-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jamenamcinteer/react-qr-barcode-scanner/security/code-scanning/3](https://github.com/jamenamcinteer/react-qr-barcode-scanner/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. For this workflow:
- `contents: read` is needed to read repository files.
- `issues: write` is required to create issues.
- `pull-requests: write` is required to create pull requests.
- `contents: write` is required for branch creation and pushing changes.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`dependency-check`) to limit its scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
